### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/j8kin/fantasy-empires-wars/security/code-scanning/1](https://github.com/j8kin/fantasy-empires-wars/security/code-scanning/1)

To fix the issue, you should explicitly set the permissions for the workflow or job. Since the workflow is primarily for checking out code, installing dependencies, running tests, and building the project – none of which require write access to the repository or related entities – the minimal starting point is most appropriate:  
Add a `permissions:` block at the top level, immediately after the workflow `name: CI`, or directly under the specific job if finer granularity is desired.  
Set `contents: read`, which will deny write access to repository contents for this workflow and jobs therein, adhering to least privilege.  
No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
