### PR TITLE
[Issue #125] Feature: Enhance PURE MAGIC Doctrine.

### DIFF
--- a/src/map/magic/calculateMana.ts
+++ b/src/map/magic/calculateMana.ts
@@ -4,7 +4,9 @@ import { updatePlayerMana } from '../../systems/gameStateActions';
 import { getManaSource } from '../../domain/mana/manaSource';
 import { getSpecialLandKinds } from '../../domain/land/landRelationships';
 import { getRealmLands } from '../../selectors/landSelectors';
+import { Doctrine } from '../../state/player/PlayerProfile';
 import { TreasureName } from '../../types/Treasures';
+import { Mana } from '../../types/Mana';
 import type { GameState } from '../../state/GameState';
 
 export const calculateMana = (gameState: GameState): GameState => {
@@ -18,18 +20,31 @@ export const calculateMana = (gameState: GameState): GameState => {
 
   allHeroes.forEach((mage) => {
     const manaSource = getManaSource({ heroType: mage.type })!;
-    updatedState = updatePlayerMana(updatedState, turnOwner.id, manaSource.type, mage.mana || 0);
+    updatedState = updatePlayerMana(updatedState, turnOwner.id, manaSource.type, mage.mana ?? 0);
+    if (turnOwner.playerProfile.doctrine === Doctrine.PURE_MAGIC) {
+      // mages from pure magic produce 10% of the main mage mana in all other mana schools
+      Object.values(Mana)
+        .filter((m) => m !== manaSource.type)
+        .forEach((m) => {
+          updatedState = updatePlayerMana(updatedState, turnOwner.id, m, (mage.mana ?? 0) * 0.1);
+        });
+    }
   });
 
   getRealmLands(updatedState)
     .filter((land) => getSpecialLandKinds().includes(land.type))
     .forEach((land) => {
       const manaSource = getManaSource({ landKind: land.type })!;
-      if (allHeroes.some((h) => manaSource.heroTypes.includes(h.type))) {
-        updatedState = updatePlayerMana(updatedState, turnOwner.id, manaSource.type, 1); // each special land gives 1 mana of a related type
+      // Special Lands generate mana only if the player is Pure Magic or has a hero of a related type
+      if (
+        turnOwner.playerProfile.doctrine === Doctrine.PURE_MAGIC ||
+        allHeroes.some((h) => manaSource.heroTypes.includes(h.type))
+      ) {
+        updatedState = updatePlayerMana(updatedState, turnOwner.id, manaSource.type, 1);
       }
+      // add ADDITIONAL mana even if there are no heroes of a related type
       if (hasHeartStone) {
-        updatedState = updatePlayerMana(updatedState, turnOwner.id, manaSource.type, 1); // add mana even if there are no heroes of a related type
+        updatedState = updatePlayerMana(updatedState, turnOwner.id, manaSource.type, 1);
       }
     });
 

--- a/src/map/recruiting/completeRecruiting.ts
+++ b/src/map/recruiting/completeRecruiting.ts
@@ -10,7 +10,7 @@ import { generateHeroName } from './heroNameGeneration';
 import { heroRecruitingMessage } from './heroRecruitingMessage';
 import { warMachineFactory } from '../../factories/warMachineFactory';
 import { getTurnOwner } from '../../selectors/playerSelectors';
-import { levelUpRegulars } from '../../systems/unitsActions';
+import { levelUpHero, levelUpRegulars } from '../../systems/unitsActions';
 import { Doctrine } from '../../state/player/PlayerProfile';
 import { EmpireEventKind } from '../../types/EmpireEvent';
 import type { EmpireEvent } from '../../types/EmpireEvent';
@@ -46,6 +46,10 @@ export const completeRecruiting = (gameState: GameState): EmpireEvent[] => {
 
           if (isHeroType(s.unit)) {
             const hero = heroFactory(s.unit, generateHeroName(s.unit));
+            if (getTurnOwner(gameState).playerProfile.doctrine === Doctrine.PURE_MAGIC) {
+              // all pure magic heroes recruited on level 10
+              while (hero.level < 10) levelUpHero(hero, getTurnOwner(gameState).playerProfile.doctrine);
+            }
             recruitEvents.push({
               status: EmpireEventKind.Success,
               message: heroRecruitingMessage(hero),


### PR DESCRIPTION
Recruit all heroes at level 10 for the PURE MAGIC doctrine. Enable heroes to produce all types of mana, contributing 10% of their primary mana value per turn. Allow special lands to produce mana even without a related hero.